### PR TITLE
refactor:rename 'install'

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -64,7 +64,7 @@ const components: {
     RadioGroup,
 };
 
-  const install = (app:any) => {
+  const yikeUI = (app:any) => {
     // 全局挂载 原型函数 过组件实例调用的属性   this.$message
     for (const componentItme in components) {
         app.component(componentItme, components[componentItme])
@@ -74,11 +74,11 @@ const components: {
   }
 
 //全局引入使用
-// export default install
+// export default yikeUI
 
 //按需引入使用
 export {
-    install,//全局
+  yikeUI,//全局
     Theme,//主题
     Button,//按钮
     Message,//全局信息


### PR DESCRIPTION

重构 `install` -> `yikeUI`

`app.use(install)` 看起来很奇怪，字面上看起来使用了 `install`. 没有人知道 install 了什么. 

建议这个 `install` 变成项目关键字. 例如 `['yikeUI','yikeDesign']`等等...